### PR TITLE
Need for Speed Nitro Wii

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Note that source code is only included for codes that use hooks, excluding pure 
 Games that had codes updated and source code included after **May 27, 2026**:
 
 - **[GameCube]** Mario Kart: Double Dash!! (Retail and Debug)
+- **[Wii]** Need for Speed Nitro (Retail and Prototype)
 - **[Switch]** Splatoon 2
 
 ---

--- a/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/DisableWaitForButtonPressAtRaceStart/DisableWaitForButtonPressAtRaceStart.md
+++ b/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/DisableWaitForButtonPressAtRaceStart/DisableWaitForButtonPressAtRaceStart.md
@@ -1,0 +1,13 @@
+## DisableWaitForButtonPressAtRaceStart
+
+Enables DisableWaitForButtonPressAtRaceStart debug flag.
+
+Makes it so you don't need to press A at the start of a race for the countdown to begin.
+
+<details>
+<summary>Show code</summary>
+
+```
+042620A0 38600001
+```
+</details>

--- a/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFE/SkipFE.md
+++ b/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFE/SkipFE.md
@@ -1,0 +1,13 @@
+## SkipFE
+
+Enables SkipFE debug flag.
+
+Makes you boot directly into a race, skipping the frontend. Certain things are forced, like the player vehicle, number of laps and more. This repository includes codes to modify some of these values.
+
+<details>
+<summary>Show code</summary>
+
+```
+04745A48 00000001
+```
+</details>

--- a/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFEAIControlPlayerCar/SkipFEAIControlPlayerCar.md
+++ b/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFEAIControlPlayerCar/SkipFEAIControlPlayerCar.md
@@ -1,0 +1,13 @@
+## SkipFEAIControlPlayerCar
+
+Enables SkipFEAIControlPlayerCar debug flag. 
+
+Makes your car AI controlled in SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+```
+00745AD4 00000001
+```
+</details>

--- a/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFEBootFlow/SkipFEBootFlow.md
+++ b/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFEBootFlow/SkipFEBootFlow.md
@@ -1,0 +1,13 @@
+## SkipFEBootFlow
+
+Enables SkipFEBootFlow debug flag.
+
+Makes it so you boot directly to the main menu, skipping opening movies and such.
+
+<details>
+<summary>Show code</summary>
+
+```
+00745AD4 00000001
+```
+</details>

--- a/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFEDisableCops/SkipFEDisableCops.md
+++ b/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFEDisableCops/SkipFEDisableCops.md
@@ -1,0 +1,13 @@
+## SkipFEDisableCops
+
+Enables SkipFEDisableCops debug flag. 
+
+Disables cops in SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+```
+00745B01 00000001
+```
+</details>

--- a/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFENumAICars/SkipFENumAICars.md
+++ b/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFENumAICars/SkipFENumAICars.md
@@ -1,0 +1,13 @@
+## SkipFENumAICars
+
+Changes the number of AI opponents in SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+XX: Amount
+
+```
+04742660 0000000X
+```
+</details>

--- a/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFENumLaps/SkipFENumLaps.md
+++ b/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFENumLaps/SkipFENumLaps.md
@@ -1,0 +1,15 @@
+## SkipFENumLaps
+
+Changes the number of laps of SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+XX: Laps in hex
+
+Default is 02
+
+```
+04742664 000000XX
+```
+</details>

--- a/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFEPlayerCar/SkipFEPlayerCar.md
+++ b/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFEPlayerCar/SkipFEPlayerCar.md
@@ -1,0 +1,26 @@
+## SkipFEPlayerCar
+
+Changes the car the player drives in SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+Modify the Xs with the car string. Read the example for reference
+
+```
+067426C8 00000008
+XXXXXXXX XXXXXX00
+```
+</details>
+
+<details>
+<summary>Code Example</summary>
+
+Forces "mmini" (config.txt found in this build forces this car)
+
+```
+067426C8 00000008
+6D6D696E 69000000
+```
+</details>
+

--- a/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFERaceID/SkipFERaceID.md
+++ b/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFERaceID/SkipFERaceID.md
@@ -1,0 +1,25 @@
+## SkipFERaceID
+
+Changes the forced race event ID used for SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+Modify the Xs with the race ID string. Read the example for reference
+
+```
+065B02FC 00000008
+XXXXXXXX XXXXXXXX
+```
+</details>
+
+<details>
+<summary>Code Example</summary>
+
+Forces "gpmm_8p"
+
+```
+065B02FC 00000008
+67706D6D 5F387000
+```
+</details>

--- a/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFETrackNumber/SkipFETrackNumber.md
+++ b/Wii/Need for Speed Nitro (April 9th, 2009 Prototype)/SkipFETrackNumber/SkipFETrackNumber.md
@@ -1,0 +1,15 @@
+## SkipFETrackNumber
+
+Changes the forced track number ID used for SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+Change XXXX to track number.
+
+Default is 07DB (2011)
+
+```
+04742650 0000XXXX
+```
+</details>

--- a/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFE/SkipFE.md
+++ b/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFE/SkipFE.md
@@ -1,0 +1,13 @@
+## SkipFE
+
+Enables SkipFE debug flag.
+
+Makes you boot directly into a race, skipping the frontend. Certain things are forced, like the player vehicle, number of laps and more. This repository includes codes to modify some of these values.
+
+<details>
+<summary>Show code</summary>
+
+```
+04745A48 00000001
+```
+</details>

--- a/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFEAIControlPlayerCar/SkipFEAIControlPlayerCar.md
+++ b/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFEAIControlPlayerCar/SkipFEAIControlPlayerCar.md
@@ -1,0 +1,13 @@
+## SkipFEAIControlPlayerCar
+
+Enables SkipFEAIControlPlayerCar debug flag. 
+
+Makes your car AI controlled in SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+```
+006D9E24 00000001
+```
+</details>

--- a/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFEBootFlow/SkipFEBootFlow.md
+++ b/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFEBootFlow/SkipFEBootFlow.md
@@ -1,0 +1,13 @@
+## SkipFEBootFlow
+
+Enables SkipFEBootFlow debug flag.
+
+Makes it so you boot directly to the main menu, skipping opening movies and such.
+
+<details>
+<summary>Show code</summary>
+
+```
+006D9E51 00000001
+```
+</details>

--- a/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFEDisableCops/SkipFEDisableCops.md
+++ b/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFEDisableCops/SkipFEDisableCops.md
@@ -1,0 +1,13 @@
+## SkipFEDisableCops
+
+Enables SkipFEDisableCops debug flag. 
+
+Disables cops in SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+```
+006D9E10 00000001
+```
+</details>

--- a/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFENumAICars/SkipFENumAICars.md
+++ b/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFENumAICars/SkipFENumAICars.md
@@ -1,0 +1,13 @@
+## SkipFENumAICars
+
+Changes the number of AI opponents in SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+XX: Amount
+
+```
+046D6F28 0000000X
+```
+</details>

--- a/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFENumLaps/SkipFENumLaps.md
+++ b/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFENumLaps/SkipFENumLaps.md
@@ -1,0 +1,15 @@
+## SkipFENumLaps
+
+Changes the number of laps of SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+XX: Laps in hex
+
+Default is 02
+
+```
+046D6F30 000000XX
+```
+</details>

--- a/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFEPlayerCar/SkipFEPlayerCar.md
+++ b/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFEPlayerCar/SkipFEPlayerCar.md
@@ -1,0 +1,26 @@
+## SkipFEPlayerCar
+
+Changes the car the player drives in SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+Modify the Xs with the car string. Read the example for reference
+
+```
+066D6F90 00000008
+XXXXXXXX XXXXXX00
+```
+</details>
+
+<details>
+<summary>Code Example</summary>
+
+Forces "mmini" (config.txt found in the other Prototype build forces this car)
+
+```
+066D6F90 00000008
+6D6D696E 69000000
+```
+</details>
+

--- a/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFERaceID/SkipFERaceID.md
+++ b/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFERaceID/SkipFERaceID.md
@@ -1,0 +1,25 @@
+## SkipFERaceID
+
+Changes the forced race event ID used for SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+Modify the Xs with the race ID string. Read the example for reference
+
+```
+0656C8EC 00000008
+XXXXXXXX XXXXXXXX
+```
+</details>
+
+<details>
+<summary>Code Example</summary>
+
+Forces "gpmm_8p"
+
+```
+0656C8EC 00000008
+67706D6D 5F387000
+```
+</details>

--- a/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFETrackNumber/SkipFETrackNumber.md
+++ b/Wii/Need for Speed Nitro (March 11, 2009 Focus Test Prototype)/SkipFETrackNumber/SkipFETrackNumber.md
@@ -1,0 +1,15 @@
+## SkipFETrackNumber
+
+Changes the forced track number ID used for SkipFE races.
+
+<details>
+<summary>Show code</summary>
+
+Change XXXX to track number.
+
+Default is 07E7 (2023)
+
+```
+046D6F1C 0000XXXX
+```
+</details>

--- a/Wii/Need for Speed Nitro (NTSC-J)/Debug Cameras/Debug Cameras.md
+++ b/Wii/Need for Speed Nitro (NTSC-J)/Debug Cameras/Debug Cameras.md
@@ -1,0 +1,60 @@
+## Debug Cameras
+
+Restores the Debug Camera enable toggle and assigns buttons for Turbo and Super Turbo movement speeds.
+
+There are two Debug Camera modes left in the game:
+
+### Debug World Camera
+
+Free-fly camera that allows you to move the camera freely anywhere. Pressing `Plus` drops the car to the camera's location.
+
+Normally, there are buttons for Turbo and Super Turbo movement speeds, which make the camera move faster. However, these buttons are not assigned in the Wii version.
+
+### Debug Car Camera
+Also known as Orbit Camera. Camera stays locked on the car, allowing you to rotate around the car and zoom.
+
+---
+
+The game still contains both camera modes in retail, but the button handler to enable them is removed.
+
+This code restores the toggle, allowing `Minus` to enter Debug Camera mode, and assigns buttons for the Debug World Camera's Turbo and Super Turbo movement speeds.
+
+Note that you must be using a Wiimote and Nunchuk on port 2 (Wiimote 2).
+
+#### Controls:
+`Minus` toggles camera modes.
+
+`D-Pad` moves camera (Debug World Camera).
+
+`Plus` drops the car (Debug World Camera).
+
+`A` moves camera up (Debug World Camera).
+
+`B` moves camera down (Debug World Camera).
+
+`C` moves camera faster (Debug World Camera Turbo mode).
+
+`Z` moves camera way faster (Debug World Camera Super Turbo mode).
+
+`Stick` rotates camera (both modes).
+
+<details>
+<summary>Show code</summary>
+
+```
+C20653E0 0000000D
+38600000 38800000
+3D80806F A16C3D82
+71606000 41820018
+716B2000 4082000C
+38600001 48000008
+38800001 906DC640
+908DC644 A18C3D86
+718C1000 41820020
+38600001 3C808055
+60847838 3D808006
+618C5C30 7D8903A6
+4E800421 809D0018
+60000000 00000000
+```
+</details>

--- a/Wii/Need for Speed Nitro (NTSC-J)/Debug Cameras/Debug Cameras.md
+++ b/Wii/Need for Speed Nitro (NTSC-J)/Debug Cameras/Debug Cameras.md
@@ -6,7 +6,7 @@ There are two Debug Camera modes left in the game:
 
 ### Debug World Camera
 
-Free-fly camera that allows you to move the camera freely anywhere. Pressing `Plus` drops the car to the camera's location.
+Free fly camera that allows you to move the camera freely anywhere. Pressing `Plus` drops the car to the camera's location.
 
 Normally, there are buttons for Turbo and Super Turbo movement speeds, which make the camera move faster. However, these buttons are not assigned in the Wii version.
 
@@ -22,7 +22,7 @@ This code restores the toggle, allowing `Minus` to enter Debug Camera mode, and 
 Note that you must be using a Wiimote and Nunchuk on port 2 (Wiimote 2).
 
 #### Controls:
-`Minus` toggles camera modes.
+`Minus` cycles camera modes.
 
 `D-Pad` moves camera (Debug World Camera).
 
@@ -58,3 +58,5 @@ C20653E0 0000000D
 60000000 00000000
 ```
 </details>
+
+The ASM source code can be found [here](source.s).

--- a/Wii/Need for Speed Nitro (NTSC-J)/Debug Cameras/source.s
+++ b/Wii/Need for Speed Nitro (NTSC-J)/Debug Cameras/source.s
@@ -1,0 +1,64 @@
+# Game: Need for Speed Nitro (Wii)
+# Code: Debug Cameras
+
+
+# CameraAI::Director::SelectAction + 0x410
+# 800653E0
+
+# Sets Turbo and Super Turbo mode bools based on C and Z button hold
+
+# Changes camera action to CDActionDebug when Minus is pressed to enable Debug Camera
+
+# Based on Wiimote connected to port 2 (Because Debug Camera is controlled by controller on 2nd port)
+
+# Game handles camera control and camera modes toggle
+
+
+# Functions
+.set CameraAI__SetAction, 0x80065C30
+
+# Globals
+.set addr_Wiimote2ButtonHold, 0x806F3D82
+.set addr_Wiimote2ButtonTrig, 0x806F3D86
+.set addr_CDActionDebug_string, 0x80557838
+
+# Defines
+.set BUTTON_MINUS, 0x1000
+.set BUTTON_Z_NUNCHUK, 0x2000
+.set BUTTON_C_NUNCHUK, 0x4000
+
+li r3, 0
+li r4, 0
+
+lis r12, addr_Wiimote2ButtonHold@h
+lhz r11, addr_Wiimote2ButtonHold@l (r12)
+andi. r0, r11, BUTTON_C_NUNCHUK | BUTTON_Z_NUNCHUK
+beq storeTurbo
+
+andi. r11, r11, BUTTON_Z_NUNCHUK
+bne setSuperTurbo
+
+li r3, 1
+b storeTurbo
+
+setSuperTurbo:
+li r4, 1
+
+storeTurbo:
+stw r3, -0x39C0 (r13)
+stw r4, -0x39BC (r13)
+
+lhz r12, addr_Wiimote2ButtonTrig@l (r12)
+andi. r12, r12, BUTTON_MINUS
+beq end
+
+li r3, 1
+lis r4, addr_CDActionDebug_string@h
+ori r4, r4, addr_CDActionDebug_string@l
+lis r12, CameraAI__SetAction@h
+ori r12, r12, CameraAI__SetAction@l
+mtctr r12
+bctrl
+
+end:
+lwz r4, 0x18 (r29)

--- a/Wii/Need for Speed Nitro (NTSC-J)/Debug Cameras/source.s
+++ b/Wii/Need for Speed Nitro (NTSC-J)/Debug Cameras/source.s
@@ -11,7 +11,7 @@
 
 # Based on Wiimote connected to port 2 (Because Debug Camera is controlled by controller on 2nd port)
 
-# Game handles camera control and camera modes toggle
+# Game handles camera control and camera mode change
 
 
 # Functions

--- a/Wii/Need for Speed Nitro (NTSC-J)/DisableWaitForButtonPressAtRaceStart/DisableWaitForButtonPressAtRaceStart.md
+++ b/Wii/Need for Speed Nitro (NTSC-J)/DisableWaitForButtonPressAtRaceStart/DisableWaitForButtonPressAtRaceStart.md
@@ -1,0 +1,13 @@
+## DisableWaitForButtonPressAtRaceStart
+
+Enables DisableWaitForButtonPressAtRaceStart debug flag.
+
+Makes it so you don't need to press A at the start of a race for the countdown to begin.
+
+<details>
+<summary>Show code</summary>
+
+```
+007CF1A0 00000001
+```
+</details>

--- a/Wii/Need for Speed Nitro (NTSC-J)/SkipFEBootFlow/SkipFEBootFlow.md
+++ b/Wii/Need for Speed Nitro (NTSC-J)/SkipFEBootFlow/SkipFEBootFlow.md
@@ -1,0 +1,13 @@
+## SkipFEBootFlow
+
+Enables SkipFEBootFlow.
+
+Makes it so you boot directly to the main menu, skipping opening movies and such.
+
+<details>
+<summary>Show code</summary>
+
+```
+007CF1AE 00000001
+```
+</details>


### PR DESCRIPTION
Added codes for Need for Speed Nitro Wii (Japan and the two recently leaked Prototype builds).

Just a few debug flag enables like SkipFE, and Debug Cameras for retail (Japan). 

Unfortunately, SkipFE softlocks the game in retail and I couldn't figure out why, so SkipFE codes are not included for retail.